### PR TITLE
refactors configure tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ ios_config_temp_config_file: "tmp_{{ inventory_hostname_short }}"
 ios_config_checkpoint_filename: chk_ansible
 ios_config_remove_temp_files: "{{ remove_temp_files | default(True) }}"
 ios_config_rollback_enabled: "{{ rollback | default(True) }}"
+ios_config_use_terminal: True
+ios_config_active_config: cfg_ansible
 
 ios_config_source:
   running: show running-config

--- a/library/ios_command.py
+++ b/library/ios_command.py
@@ -1,0 +1,241 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'network'}
+
+
+DOCUMENTATION = """
+---
+module: ios_command
+version_added: "2.1"
+author: "Peter Sprygada (@privateip)"
+short_description: Run commands on remote devices running Cisco IOS
+description:
+  - Sends arbitrary commands to an ios node and returns the results
+    read from the device. This module includes an
+    argument that will cause the module to wait for a specific condition
+    before returning or timing out if the condition is not met.
+  - This module does not support running commands in configuration mode.
+    Please use M(ios_config) to configure IOS devices.
+extends_documentation_fragment: ios
+notes:
+  - Tested against IOS 15.6
+options:
+  commands:
+    description:
+      - List of commands to send to the remote ios device over the
+        configured provider. The resulting output from the command
+        is returned. If the I(wait_for) argument is provided, the
+        module is not returned until the condition is satisfied or
+        the number of retries has expired. If a command sent to the
+        device requires answering a prompt, it is possible to pass
+        a dict containing I(command), I(answer) and I(prompt).
+        Common answers are 'y' or "\\r" (carriage return, must be
+        double quotes). See examples.
+    required: true
+  wait_for:
+    description:
+      - List of conditions to evaluate against the output of the
+        command. The task will wait for each condition to be true
+        before moving forward. If the conditional is not true
+        within the configured number of retries, the task fails.
+        See examples.
+    aliases: ['waitfor']
+    version_added: "2.2"
+  match:
+    description:
+      - The I(match) argument is used in conjunction with the
+        I(wait_for) argument to specify the match policy.  Valid
+        values are C(all) or C(any).  If the value is set to C(all)
+        then all conditionals in the wait_for must be satisfied.  If
+        the value is set to C(any) then only one of the values must be
+        satisfied.
+    default: all
+    choices: ['any', 'all']
+    version_added: "2.2"
+  retries:
+    description:
+      - Specifies the number of retries a command should by tried
+        before it is considered failed. The command is run on the
+        target device every retry and evaluated against the
+        I(wait_for) conditions.
+    default: 10
+  interval:
+    description:
+      - Configures the interval in seconds to wait between retries
+        of the command. If the command does not pass the specified
+        conditions, the interval indicates how long to wait before
+        trying the command again.
+    default: 1
+"""
+
+EXAMPLES = r"""
+tasks:
+  - name: run show version on remote devices
+    ios_command:
+      commands: show version
+
+  - name: run show version and check to see if output contains IOS
+    ios_command:
+      commands: show version
+      wait_for: result[0] contains IOS
+
+  - name: run multiple commands on remote nodes
+    ios_command:
+      commands:
+        - show version
+        - show interfaces
+
+  - name: run multiple commands and evaluate the output
+    ios_command:
+      commands:
+        - show version
+        - show interfaces
+      wait_for:
+        - result[0] contains IOS
+        - result[1] contains Loopback0
+  - name: run commands that require answering a prompt
+    ios_command:
+      commands:
+        - command: 'clear counters GigabitEthernet0/1'
+          prompt: 'Clear "show interface" counters on this interface \[confirm\]'
+          answer: 'y'
+        - command: 'clear counters GigabitEthernet0/2'
+          prompt: '[confirm]'
+          answer: "\r"
+"""
+
+RETURN = """
+stdout:
+  description: The set of responses from the commands
+  returned: always apart from low level errors (such as action plugin)
+  type: list
+  sample: ['...', '...']
+stdout_lines:
+  description: The value of stdout split into a list
+  returned: always apart from low level errors (such as action plugin)
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+failed_conditions:
+  description: The list of conditionals that have failed
+  returned: failed
+  type: list
+  sample: ['...', '...']
+"""
+import re
+import time
+
+from ansible.module_utils.network.ios.ios import run_commands
+from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.common.utils import ComplexList
+from ansible.module_utils.network.common.parsing import Conditional
+from ansible.module_utils.six import string_types
+
+
+def to_lines(stdout):
+    for item in stdout:
+        if isinstance(item, string_types):
+            item = str(item).split('\n')
+        yield item
+
+
+def parse_commands(module, warnings):
+    command = ComplexList(dict(
+        command=dict(key=True),
+        prompt=dict(),
+        answer=dict()
+    ), module)
+    commands = command(module.params['commands'])
+    for item in list(commands):
+        configure_type = re.match(r'conf(?:\w*)(?:\s+(\w+))?', item['command'])
+        if module.check_mode:
+            if configure_type and configure_type.group(1) not in ('confirm', 'replace', 'revert', 'network'):
+                module.fail_json(
+                    msg='ios_command does not support running config mode '
+                        'commands.  Please use ios_config instead'
+                )
+    return commands
+
+
+def main():
+    """main entry point for module execution
+    """
+    argument_spec = dict(
+        commands=dict(type='list', required=True),
+
+        wait_for=dict(type='list', aliases=['waitfor']),
+        match=dict(default='all', choices=['all', 'any']),
+
+        retries=dict(default=10, type='int'),
+        interval=dict(default=1, type='int')
+    )
+
+    argument_spec.update(ios_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    result = {'changed': False}
+
+    warnings = list()
+    check_args(module, warnings)
+    commands = parse_commands(module, warnings)
+    result['warnings'] = warnings
+
+    wait_for = module.params['wait_for'] or list()
+    conditionals = [Conditional(c) for c in wait_for]
+
+    retries = module.params['retries']
+    interval = module.params['interval']
+    match = module.params['match']
+
+    while retries > 0:
+        responses = run_commands(module, commands)
+
+        for item in list(conditionals):
+            if item(responses):
+                if match == 'any':
+                    conditionals = list()
+                    break
+                conditionals.remove(item)
+
+        if not conditionals:
+            break
+
+        time.sleep(interval)
+        retries -= 1
+
+    if conditionals:
+        failed_conditions = [item.raw for item in conditionals]
+        msg = 'One or more conditional statements have not been satisfied'
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
+
+    result.update({
+        'changed': False,
+        'stdout': responses,
+        'stdout_lines': list(to_lines(responses))
+    })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/configure.yaml
+++ b/tasks/configure.yaml
@@ -4,114 +4,136 @@
     msg: "missing required argument: ios_config_text"
   when: ios_config_text is undefined or not ios_config_text
 
-- name: check if old checkpoint file exists on device
+# check if any reminents are left over from a previous run and remove them
+# prior to starting the configuration tasks.
+- name: check if stale temporarary files exist on target device
   cli:
     command: dir
   register: ios_dir_listing
 
-- name: remove old checkpoint file from device
+- name: remove temporary files from target device
   cli:
-    command: "delete /force flash://{{ ios_config_checkpoint_filename }}"
-  when: ios_config_checkpoint_filename in ios_dir_listing.stdout
+    command: "delete /force flash:/{{ filename }}"
+  when: ios_config_remove_temp_files and filename in ios_dir_listing.stdout
+  loop:
+    - "{{ ios_config_active_config }}"
+    - "{{ ios_config_checkpoint_filename }}"
+    - "{{ ios_config_temp_config_file }}"
+  loop_control:
+    loop_var: filename
 
-- name: checkpoint existing configuration for rollback
-  ios_command_local:
+# copy the current running-config to the local flash disk on the target device.
+# This will be used both for restoring the current config if a failure happens
+# as well as performing a configuration diff once the new config has been
+# loaded.
+- name: create a checkpoint of the current running-config
+  ios_command:
     commands:
       - command: "copy running-config flash:{{ ios_config_checkpoint_filename }}"
         prompt: ["? "]
         answer: "{{ ios_config_checkpoint_filename }}"
-  when: ios_config_rollback_enabled
 
+
+# these next two tasks are responsible for taking the provided configuration,
+# templating it and preparing it for loading onto the target device
+- name: create temp working dir
+  file:
+    path: "{{ ios_config_working_dir }}"
+    state: directory
+  run_once: true
+  check_mode: false
+  changed_when: False
+
+# always set check mode to false here as this task needs to always run
+# in order to fully execute the task list.
+- name: template source config
+  copy:
+    content: "{{ ios_config_text }}"
+    dest: "{{ ios_config_working_dir }}/{{ ios_config_temp_config_file }}"
+  check_mode: false
+  changed_when: False
+
+# in order to transfer the configuration files to the target network
+# device, the scp server feature must be enabled in the current
+# running-config
+- name: enable the ios scp server
+  cli:
+    command: "{{ line }}"
+  loop:
+    - configure terminal
+    - ip scp server enable
+    - end
+  loop_control:
+    loop_var: line
+
+# copy the templates configuration to the target device using scp and
+# store the file on the device local flash drive
+- name: copy configuration to device
+  net_put:
+    src: "{{ ios_config_working_dir }}/{{ ios_config_temp_config_file }}"
+    dest: "flash:/{{ ios_config_temp_config_file }}"
+  changed_when: False
+
+# if running in check mode, the configuration should not be loaded on
+# the target device because that could have undesired results, so
+# just print a warning message here.
+- name: display message due to check mode
+  debug:
+    msg: not loading configuration due to check mode
+  when: ansible_check_mode
+
+# the block of tasks here are repsonsible for loading the configuration onto
+# the target device.  There are one of three options here controlled by role
+# variables:
+#
+#  * replace config - use the copy command with replace
+#  * merge config - use the copy command (merge)
+#  * load config - enter config mode and push the config lines
+#
 - name: load configuration onto target device
   block:
-    - name: create temp working dir
-      file:
-        path: "{{ ios_config_working_dir }}"
-        state: directory
-      run_once: true
-      check_mode: false
+    - name: replace current active configuration
+      cli:
+        command: "config replace flash:/{{ ios_config_temp_config_file }} force"
+      when: ios_config_replace
 
-      # always set check mode to false here as this task needs to always run
-      # in order to fully execute the task list.
-    - name: template source config
-      copy:
-        content: "{{ ios_config_text }}"
-        dest: "{{ ios_config_working_dir }}/{{ ios_config_temp_config_file }}"
-      check_mode: false
+    - name: merge with current active configuration
+      cli:
+        command: "copy flash:/{{ ios_config_temp_config_file }} force"
+      when: not ios_config_replace and not ios_config_use_terminal
 
-    - name: load configuration file onto target device
+    - name: load configuration lines into target device
       block:
-        - name: enable the ios scp server
+        - name: enter configuration mode
+          cli:
+            command: "configure terminal"
+
+        - name: load configuration lines into target device
           cli:
             command: "{{ line }}"
-          loop:
-            - configure terminal
-            - ip scp server enable
-            - end
+          loop: "{{ ios_config_text | to_lines }}"
           loop_control:
             loop_var: line
+          when: line != 'end'
 
-        - name: remove old config file from device
+        - name: exit configuration mode
           cli:
-            command: "delete /force flash:/{{ ios_config_temp_config_file }}"
-          when: ios_config_temp_config_file in ios_dir_listing.stdout
-
-        - name: copy configuration to device
-          net_put:
-            src: "{{ ios_config_working_dir }}/{{ ios_config_temp_config_file }}"
-            dest: "flash:/{{ ios_config_temp_config_file }}"
-
-        - name: generate ios diff
-          cli:
-            command: "show archive config differences flash:{{ ios_config_checkpoint_filename }} flash:{{ ios_config_temp_config_file }}"
-          register: ios_config_diff
-
-        - name: display config diff
-          debug:
-            msg: "{{ ios_config_diff.stdout.splitlines() }}"
-
-        - name: replace current active configuration
-          cli:
-            command: "config replace flash:/{{ ios_config_temp_config_file }} force"
-          when: not ansible_check_mode and ios_config_replace
-          changed_when: ios_config_diff.stdout
-
-        - name: merge current active configuration
-          cli:
-            command: "copy flash:/{{ ios_config_temp_config_file }} force"
-          when: not ansible_check_mode and not ios_config_replace
-          changed_when: ios_config_diff.stdout
-
-        - name: remove uploaded configuration
-          cli:
-            command: "delete /force flash:/{{ ios_config_temp_config_file }}"
-          when: ios_config_remove_temp_files
-
-        - name: remove temp working dir
-          file:
-            path: "{{ ios_config_working_dir }}"
-            state: absent
-          run_once: true
-          when: ios_config_remove_temp_files
+            command: end
 
       rescue:
-        - name: remove uploaded configuration
+        - name: exit configuration mode
           cli:
-            command: "delete /force flash:/{{ ios_config_temp_config_file }}"
-          when: ios_config_remove_temp_files
-
-        - name: remove temp working dir
-          file:
-            path: "{{ ios_config_working_dir }}"
-            state: absent
-          run_once: true
-          when: ios_config_remove_temp_files
+            command: end
 
         - name: set host failed
           fail:
-            msg: "error loading configuration onto target device"
+            msg: "error loading configuration lines"
+      when: ios_config_use_terminal and not ios_config_replace
 
   rescue:
+      # since the host has failed during the configuration load, the role by
+      # default will initiate a restore sequence.  the restore sequence will
+      # load the previous running-config with the replace option enabled.
     - name: display message
       debug:
         msg: "error configuring device, starting rollback"
@@ -122,11 +144,9 @@
       when: ios_configuration_rollback_pre_hook is defined and ios_config_rollback_enabled
 
     - name: rollback configuration
-      ios_command_local:
-        commands:
-          - command: "copy flash:/{{ ios_config_checkpoint_filename }} running-config"
-            prompt: ["? "]
-            answer: "running-config"
+      cli:
+        command: "config replace flash:/{{ ios_config_temp_config_file }} force"
+      when: ios_config_rollback_enabled
 
     - name: remove configuration checkpoint file
       cli:
@@ -137,6 +157,23 @@
       include_tasks: "{{ ios_configuration_rollback_post_hook }}"
       when: ios_configuration_rollback_post_hook is defined and ios_config_rollback_enabled
 
+    - name: remove remote temp files
+      cli:
+        command: "delete /force flash:/{{ filename }}"
+      loop:
+        - "{{ ios_config_temp_config_file }}"
+        - "{{ ios_config_checkpoint_filename }}"
+      loop_control:
+        loop_var: filename
+      when: ios_config_remove_temp_files
+
+    - name: remove local temp working dir
+      file:
+        path: "{{ ios_config_working_dir }}"
+        state: absent
+      run_once: true
+      when: ios_config_remove_temp_files
+
     - name: display message
       debug:
         msg: "successfully completed configuration rollback"
@@ -146,7 +183,53 @@
       fail:
         msg: "error loading configuration onto target device"
 
-- name: remove configuration checkpoint file
+  when: not ansible_check_mode
+
+# copy the updated running-config to the local flash device to be used to
+# generate a configuration diff between the before and after
+# running-configurations.
+- name: copy running-config to active config
+  ios_command:
+    commands:
+      - command: "copy running-config flash:{{ ios_config_active_config }}"
+        prompt: ["? "]
+        answer: "{{ ios_config_active_config }}"
+
+# generate the configuration diff and display the diff to stdout.  only set
+# changed if there are lines in the diff that have changed
+- name: generate ios diff
   cli:
-    command: "delete /force flash:/{{ ios_config_checkpoint_filename }}"
-  when: ios_config_rollback_enabled and ios_config_remove_temp_files
+    command: "show archive config differences flash:{{ ios_config_checkpoint_filename }} flash:{{ ios_config_active_config }}"
+  register: ios_config_diff
+  changed_when: "'No changes were found' not in ios_config_diff.stdout"
+
+- name: display config diff
+  debug:
+    msg: "{{ ios_config_diff.stdout.splitlines() }}"
+  when: not ansible_check_mode
+
+# refresh the list of files currently on the target network device flash
+# drive and remote all temp files
+- name: update local directory listing
+  cli:
+    command: dir
+  register: ios_dir_listing
+
+- name: remove remote temp files from flash
+  cli:
+    command: "delete /force flash:/{{ filename }}"
+  loop:
+    - "{{ ios_config_active_config }}"
+    - "{{ ios_config_checkpoint_filename }}"
+    - "{{ ios_config_temp_config_file }}"
+  loop_control:
+    loop_var: filename
+  when: ios_config_remove_temp_files and filename in ios_dir_listing.stdout
+
+- name: remove local temp working dir
+  file:
+    path: "{{ ios_config_working_dir }}"
+    state: absent
+  run_once: true
+  when: ios_config_remove_temp_files
+  changed_when: False

--- a/tasks/load_config.yaml
+++ b/tasks/load_config.yaml
@@ -2,7 +2,7 @@
 - name: load config file contents
   set_fact:
     ios_config_text: "{{ lookup('config_template', ios_config_file) | join('\n') }}"
-  when: ios_config_file is defined
+  when: ios_config_file != ''
 
 - name: invoke configure
   include_tasks: configure.yaml


### PR DESCRIPTION
This change rearranges the ios configure tasks and provides support for
loading the configuration from the terminal as opposed to the merge
function (which is still supported).  The configure tasks will also now
generate the diff post config push and use the diff output to determine
if a change is made.