### PR TITLE
adds new parser template for lldp neighbors

### DIFF
--- a/filter_plugins/ios.py
+++ b/filter_plugins/ios.py
@@ -1,0 +1,35 @@
+#
+# (c) 2018 Red Hat, Inc.
+#
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+
+INTERFACE_NAMES = {
+    'Gi': 'GigabitEthernet',
+}
+
+
+def expand_interface_name(name):
+    match = re.match('([a-zA-Z]*)', name)
+    if match and match.group(1) in INTERFACE_NAMES:
+        matched = match.group(1)
+        name = name.replace(matched, INTERFACE_NAMES[matched])
+    return name
+
+
+class FilterModule(object):
+    """Filters for working with output from network devices"""
+
+    filter_map = {
+        'expand_interface_name': expand_interface_name
+    }
+
+    def filters(self):
+        return self.filter_map

--- a/parser_templates/cli/show_lldp_neighbors_detail.yaml
+++ b/parser_templates/cli/show_lldp_neighbors_detail.yaml
@@ -1,0 +1,54 @@
+---
+- name: parser meta data
+  parser_metadata:
+    version: 1.0
+    command: show lldp neighbors detail
+    network_os: ios
+
+- name: match sections
+  pattern_match:
+    regex: "^-----.*"
+    match_all: yes
+    match_greedy: yes
+  register: context
+
+- name: parse lldp neighbors
+  pattern_group:
+    - name: parse local port
+      pattern_match:
+        regex: "Local Intf: (.+)"
+        content: "{{ item }}"
+      register: local_port
+
+    - name: parse remote prort
+      pattern_match:
+        regex: "Port id: (.+)"
+        content: "{{ item }}"
+      register: remote_port
+
+    - name: parse remote host
+      pattern_match:
+        regex: "System Name: (.+)"
+        content: "{{ item }}"
+      register: remote_host
+
+  loop: "{{ context }}"
+  register: matches
+
+- name: build lldp neighbor facts
+  register: lldp
+  export: yes
+  extend: "{{ toplevel | default('cisco_ios') }}"
+  json_template:
+    template:
+      - key: neighbors
+        elements:
+          - key: port
+            value: "{{ item.local_port.matches.0  | expand_interface_name }}"
+          - key: neighbor
+            value: "{{ item.remote_host.matches.0 }}"
+          - key: neighbor_port
+            value: "{{ item.remote_port.matches.0 }}"
+        repeat_for: "{{ matches }}"
+
+

--- a/vars/get_facts_command_map.yaml
+++ b/vars/get_facts_command_map.yaml
@@ -25,13 +25,18 @@
   groups:
     - default
     - interfaces
-    
+
 - command: show ip bgp summary
   parser: show_ip_bgp_summary.yaml
   groups:
-    - bgp    
+    - bgp
 
 - command: show ip prefix-list
   parser: show_ip_prefix_list.yaml
   groups:
-    - prefix-list 
+    - prefix-list
+
+- command: show lldp neighbors detail
+  parser: show_lldp_neighbors_detail.yaml
+  groups:
+    - lldp


### PR DESCRIPTION
This change adds a new parser template that will parse the lldp
neighbors from ios and return them as json.  There is alos a filter
added to expand interface names to their full name for Gi interfaces