### PR TITLE
refactor the config tasks into config_manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Please see the documentation link for each function for details on how to use
 the function in an Ansible playbook.
 
 * get_facts [[source]](https://github.com/ansible-network/cisco_ios/blob/devel/tasks/get_facts.yaml) [[docs]](https://github.com/ansible-network/cisco_ios/blob/devel/docs/get_facts.md)
-* get_config [[source]](https://github.com/ansible-network/cisco_ios/blob/devel/tasks/get_config.yaml) [[docs]](https://github.com/ansible-network/cisco_ios/blob/devel/docs/get_config.md)
-* load_config [[source]](https://github.com/ansible-network/cisco_ios/blob/devel/tasks/load_config.yaml) [[docs]](https://github.com/ansible-network/cisco_ios/blob/devel/docs/load_config.md)
+
+### Config Manager
+* config_manager/get [[source]](https://github.com/ansible-network/cisco_ios/blob/devel/tasks/config_manager/get.yaml) [[docs]](https://github.com/ansible-network/cisco_ios/blob/devel/docs/config_manager/get.md)
+* config_manager/load [[source]](https://github.com/ansible-network/cisco_ios/blob/devel/tasks/config_manager/load.yaml) [[docs]](https://github.com/ansible-network/cisco_ios/blob/devel/docs/config_manager/loadload.md)
 
 
 ## License
@@ -29,4 +31,4 @@ GPLv3
 
 ## Author Information
 
-Ansible Network Community
+Ansible Network Communite

--- a/docs/config_manager/get.md
+++ b/docs/config_manager/get.md
@@ -1,34 +1,34 @@
 # Get configuration from device
-The `get_config` function will return the either the current active or current
+The `config_manager/get` function will return the either the current active or current
 saved configuration from an Cisco IOS devices.  This function is only
 supported over `network_cli` connections.
 
-The `get_config` function will also parse the device active configuration into
+The `config_manager/get` function will also parse the device active configuration into
 a set of host facts during its execution.  All of the parsed facts are stored
 in the ``cisco_ios.config`` top level facts key.
 
 ## How to get the device configuration
 Retrieving the configuration from the device involves just calling the
-`get_config` function from the role.  By default, the `get_config` role will
+`config_manager/get` function from the role.  By default, the `config_manager/get` role will
 return the device active (running) configuraiton.  The text configuration will
 be returned as a fact for the host.  The configuration text is stored in the
 `configuration` fact.
 
-Below is an example of calling the `get_config` function from the playbook.
+Below is an example of calling the `config_manager/get` function from the playbook.
 
 ```
 - hosts: cisco_ios
 
   roles:
     - name ansible-network.cisco_ios
-      function: get_config
+      function: config_manager/get
 ```
 
 The above playbook will return the current running config from each host listed
 in the `cisco_ios` group in inventory.
 
 ### Get the current startup config
-By default the `get_config` function will return the device running
+By default the `config_manager/get` function will return the device running
 configuration.  If you want to retrieve the device startup configuration, set
 the value of `source` to `startup`.
 
@@ -37,12 +37,12 @@ the value of `source` to `startup`.
 
   roles:
     - name ansible-network.cisco_ios
-      function: get_config
+      function: config_manager/get
       source: startup
 ```
 
 ### Implement using tasks
-The `get_config` function can also be implemented in the `tasks` during the
+The `config_manager/get` function can also be implemented in the `tasks` during the
 playbook run using either the `include_role` or `import_role` modules as shown
 below.
 
@@ -51,9 +51,9 @@ below.
 
   tasks:
     - name: collect facts from cisco ios devices
-      import_role:
+      include_role:
         name: ansible-network.cisco_ios
-        tasks_from: get_config
+        tasks_from: config_manager/get
 ```
 
 ## How to add additional parsers
@@ -61,7 +61,7 @@ below.
 The configuration facts are returned by this function are parsed using the
 parsers in the `parser_templates/config` folder.  To add a new parser, simply
 create a PR and add the new parser to the folder.  Once merged, the
-`get_config` function will automatically use the new parser.
+`config_manager/get` function will automatically use the new parser.
 
 ## Arguments
 

--- a/docs/config_manager/load.md
+++ b/docs/config_manager/load.md
@@ -1,10 +1,10 @@
 # Load configuration onto device
-The `load_config` function will take a Cisco IOS configuration file and load it
+The `config_manager/load` function will take a Cisco IOS configuration file and load it
 onto the device.  This function supports either merging the configuration with
 the current active configuration or replacing the current active configuration
 with the provided configuration file.  
 
-The `load_config` function will return the full configuration diff in the
+The `config_manager/load` function will return the full configuration diff in the
 `ios_diff` fact.
 
 NOTE: When performing a configuration replace function be sure to specify the
@@ -13,17 +13,17 @@ reconnect to your IOS device after the configuration has been loaded.
 
 ## How to load and merge a configuration
 Loading and merging a configuration file is the default operation for the
-`load_config` function.  It will take the contents of a Cisco IOS configuration
+`config_manager/load` function.  It will take the contents of a Cisco IOS configuration
 file and merge it with the current device active configurations.
 
-Below is an example of calling the `load_config` function from the playbook.
+Below is an example of calling the `config_manager/load` function from the playbook.
 
 ```
 - hosts: cisco_ios
 
   roles:
     - name ansible_network.cisco_ios
-      function: load_config
+      function: config_manager/load
       config_file: files/ios.cfg
 ```
 
@@ -31,7 +31,7 @@ The above playbook will load the specified configuration file onto each device
 in the `cisco_ios` host group.
 
 ## How to replace the current active configuration
-The `load_config` function also supports replacing the current active
+The `config_manager/load` function also supports replacing the current active
 configuration with the configuration file located on the Ansible controller.
 In order to replace the device's active configuration, set the value of the
 `config_replace` setting to `True`.
@@ -41,13 +41,13 @@ In order to replace the device's active configuration, set the value of the
 
   roles:
     - name ansible_network.cisco_ios
-      function: load_config
+      function: config_manager/load
       config_file: files/ios.cfg
       replace: yes
 ```
 
 ## How to load configuration text
-The `load_config` function also supports passing the configuration text
+The `config_manager/load` function also supports passing the configuration text
 directly into the task list for loading onto the target device instead of
 having to provide a file name. 
 
@@ -59,7 +59,7 @@ argument instead such as below.
 
   roles:
     - name ansible_network.cisco_ios
-      function: load_config
+      function: config_manager/load
       config_text: "{{ lookup('file', 'ios01.cfg') }}"
       replace: yes
 ```
@@ -67,7 +67,7 @@ argument instead such as below.
 
 
 ## Implement using tasks
-The `load_config` function can also be implemented in the `tasks` for execution
+The `config_manager/load` function can also be implemented in the `tasks` for execution
 during the play run using either the `include_role` or `import_role` modules as
 shown below.
 
@@ -76,9 +76,9 @@ shown below.
 
   tasks:
     - name: load configuration onto ios device
-      import_role:
+      include_role:
         name: ansible_network.cisco_ios
-        tasks_from: load_config
+        tasks_from: config_manager/load
       vars:
         config_file: files/ios.cfg
         replace: yes

--- a/parser_templates/config_manager/global.yaml
+++ b/parser_templates/config_manager/global.yaml
@@ -1,0 +1,23 @@
+---
+- name: parse hostname
+  pattern_match:
+    regex: "hostname (.+)"
+  register: hostname
+
+- name: parse domain-name
+  pattern_match:
+    regex: "ip domain-name (.+)"
+  register: domain_name
+
+- name: parse ip routing
+  pattern_match:
+    regex: "(ip routing)"
+  register: routing
+
+- name: set global config facts
+  set_vars:
+    hostname: "{{ hostname.matches.0 }}"
+    domain_name: "{{ domain_name.matches.0 }}"
+    routing: "{{ routing.matches.0 is defined }}"
+  export: yes
+  extend: cisco_ios.config

--- a/tasks/config_manager/edit.yaml
+++ b/tasks/config_manager/edit.yaml
@@ -1,0 +1,118 @@
+---
+- name: validate required var is set
+  fail:
+    msg: "missing required argument: ios_config_includes"
+  when: ios_config_includes is undefined
+
+# check if any reminents are left over from a previous run and remove them
+# prior to starting the configuration tasks.
+- name: check if stale temporarary files exist on target device
+  cli:
+    command: dir
+  register: ios_dir_listing
+
+- name: remove temporary files from target device
+  cli:
+    command: "delete /force flash:/{{ filename }}"
+  when: ios_config_remove_temp_files and filename in ios_dir_listing.stdout
+  loop:
+    - "{{ ios_config_active_config }}"
+    - "{{ ios_config_checkpoint_filename }}"
+  loop_control:
+    loop_var: filename
+
+# copy the current running-config to the local flash disk on the target device.
+# This will be used both for restoring the current config if a failure happens
+# as well as performing a configuration diff once the new config has been
+# loaded.
+- name: create a checkpoint of the current running-config
+  ios_command:
+    commands:
+      - command: "copy running-config flash:{{ ios_config_checkpoint_filename }}"
+        prompt: ["? "]
+        answer: "{{ ios_config_checkpoint_filename }}"
+
+- name: configure the target device
+  block:
+    # iterate over the set of includes to configure the device
+    - name: iterate over configuration tasks
+      include_tasks: "{{ item }}"
+      loop: "{{ ios_config_includes }}"
+
+  rescue:
+      # since the host has failed during the configuration load, the role by
+      # default will initiate a restore sequence.  the restore sequence will
+      # load the previous running-config with the replace option enabled.
+    - name: display message
+      debug:
+        msg: "error configuring device, starting rollback"
+      when: ios_config_rollback_enabled
+
+    - name: configuration rollback pre hook
+      include_tasks: "{{ ios_configuration_rollback_pre_hook }}"
+      when: ios_configuration_rollback_pre_hook is defined and ios_config_rollback_enabled
+
+    - name: rollback configuration
+      cli:
+        command: "config replace flash:/{{ ios_config_checkpoint_filename}} force"
+      when: ios_config_rollback_enabled
+
+    - name: remove configuration checkpoint file
+      cli:
+        command: "delete /force flash:/{{ ios_config_checkpoint_filename }}"
+      when: ios_config_remove_temp_files
+
+    - name: configuration rollback post hook
+      include_tasks: "{{ ios_configuration_rollback_post_hook }}"
+      when: ios_configuration_rollback_post_hook is defined and ios_config_rollback_enabled
+
+    - name: display message
+      debug:
+        msg: "successfully completed configuration rollback"
+      when: ios_config_rollback_enabled
+
+    - name: fail host due to config load error
+      fail:
+        msg: "error loading configuration onto target device"
+
+  when: not ansible_check_mode
+
+# copy the updated running-config to the local flash device to be used to
+# generate a configuration diff between the before and after
+# running-configurations.
+- name: copy running-config to active config
+  ios_command:
+    commands:
+      - command: "copy running-config flash:{{ ios_config_active_config }}"
+        prompt: ["? "]
+        answer: "{{ ios_config_active_config }}"
+
+# generate the configuration diff and display the diff to stdout.  only set
+# changed if there are lines in the diff that have changed
+- name: generate ios diff
+  cli:
+    command: "show archive config differences flash:{{ ios_config_checkpoint_filename }} flash:{{ ios_config_active_config }}"
+  register: ios_config_diff
+  changed_when: "'No changes were found' not in ios_config_diff.stdout"
+
+- name: display config diff
+  debug:
+    msg: "{{ ios_config_diff.stdout.splitlines() }}"
+  when: not ansible_check_mode
+
+# refresh the list of files currently on the target network device flash
+# drive and remote all temp files
+- name: update local directory listing
+  cli:
+    command: dir
+  register: ios_dir_listing
+
+- name: remove remote temp files from flash
+  cli:
+    command: "delete /force flash:/{{ filename }}"
+  loop:
+    - "{{ ios_config_active_config }}"
+    - "{{ ios_config_checkpoint_filename }}"
+  loop_control:
+    loop_var: filename
+  when: ios_config_remove_temp_files and filename in ios_dir_listing.stdout

--- a/tasks/config_manager/get.yaml
+++ b/tasks/config_manager/get.yaml
@@ -12,8 +12,8 @@
 - name: set the configuration fact
   set_fact:
     configuration: "{{ configuration.stdout }}"
-    
+
 - name: parse system configuration
   command_parser:
-    dir: "{{ role_path }}/parser_templates/config"
-    content: "{{ configuration }}"    
+    dir: "{{ role_path }}/parser_templates/config_manager"
+    content: "{{ configuration }}"

--- a/tasks/config_manager/load.yaml
+++ b/tasks/config_manager/load.yaml
@@ -1,0 +1,239 @@
+---
+- name: load config file contents
+  set_fact:
+    ios_config_text: "{{ lookup('config_template', ios_config_file) | join('\n') }}"
+  when: ios_config_file != ''
+
+- name: validate required var is set
+  fail:
+    msg: "missing required argument: ios_config_text"
+  when: ios_config_text is undefined or not ios_config_text
+
+# check if any reminents are left over from a previous run and remove them
+# prior to starting the configuration tasks.
+- name: check if stale temporarary files exist on target device
+  cli:
+    command: dir
+  register: ios_dir_listing
+
+- name: remove temporary files from target device
+  cli:
+    command: "delete /force flash:/{{ filename }}"
+  when: ios_config_remove_temp_files and filename in ios_dir_listing.stdout
+  loop:
+    - "{{ ios_config_active_config }}"
+    - "{{ ios_config_checkpoint_filename }}"
+    - "{{ ios_config_temp_config_file }}"
+  loop_control:
+    loop_var: filename
+
+# copy the current running-config to the local flash disk on the target device.
+# This will be used both for restoring the current config if a failure happens
+# as well as performing a configuration diff once the new config has been
+# loaded.
+- name: create a checkpoint of the current running-config
+  ios_command:
+    commands:
+      - command: "copy running-config flash:{{ ios_config_checkpoint_filename }}"
+        prompt: ["? "]
+        answer: "{{ ios_config_checkpoint_filename }}"
+
+# these next two tasks are responsible for taking the provided configuration,
+# templating it and preparing it for loading onto the target device
+- name: create temp working dir
+  file:
+    path: "{{ ios_config_working_dir }}"
+    state: directory
+  run_once: true
+  check_mode: false
+  changed_when: False
+
+# always set check mode to false here as this task needs to always run
+# in order to fully execute the task list.
+- name: template source config
+  copy:
+    content: "{{ ios_config_text }}"
+    dest: "{{ ios_config_working_dir }}/{{ ios_config_temp_config_file }}"
+  check_mode: false
+  changed_when: False
+
+# in order to transfer the configuration files to the target network
+# device, the scp server feature must be enabled in the current
+# running-config
+- name: enable the ios scp server
+  cli:
+    command: "{{ line }}"
+  loop:
+    - configure terminal
+    - ip scp server enable
+    - end
+  loop_control:
+    loop_var: line
+
+# copy the templates configuration to the target device using scp and
+# store the file on the device local flash drive
+- name: copy configuration to device
+  net_put:
+    src: "{{ ios_config_working_dir }}/{{ ios_config_temp_config_file }}"
+    dest: "flash:/{{ ios_config_temp_config_file }}"
+  changed_when: False
+
+# if running in check mode, the configuration should not be loaded on
+# the target device because that could have undesired results, so
+# just print a warning message here.
+- name: display message due to check mode
+  debug:
+    msg: not loading configuration due to check mode
+  when: ansible_check_mode
+
+# the block of tasks here are repsonsible for loading the configuration onto
+# the target device.  There are one of three options here controlled by role
+# variables:
+#
+#  * replace config - use the copy command with replace
+#  * merge config - use the copy command (merge)
+#  * load config - enter config mode and push the config lines
+#
+- name: load configuration onto target device
+  block:
+    - name: replace current active configuration
+      cli:
+        command: "config replace flash:/{{ ios_config_temp_config_file }} force"
+      when: ios_config_replace
+
+    - name: merge with current active configuration
+      cli:
+        command: "copy flash:/{{ ios_config_temp_config_file }} force"
+      when: not ios_config_replace and not ios_config_use_terminal
+
+    - name: load configuration lines into target device
+      block:
+        - name: enter configuration mode
+          cli:
+            command: "configure terminal"
+
+        - name: load configuration lines into target device
+          cli:
+            command: "{{ line }}"
+          loop: "{{ ios_config_text | to_lines }}"
+          loop_control:
+            loop_var: line
+          when: line != 'end'
+
+        - name: exit configuration mode
+          cli:
+            command: end
+
+      rescue:
+        - name: exit configuration mode
+          cli:
+            command: end
+
+        - name: set host failed
+          fail:
+            msg: "error loading configuration lines"
+      when: ios_config_use_terminal and not ios_config_replace
+
+  rescue:
+      # since the host has failed during the configuration load, the role by
+      # default will initiate a restore sequence.  the restore sequence will
+      # load the previous running-config with the replace option enabled.
+    - name: display message
+      debug:
+        msg: "error configuring device, starting rollback"
+      when: ios_config_rollback_enabled
+
+    - name: configuration rollback pre hook
+      include_tasks: "{{ ios_configuration_rollback_pre_hook }}"
+      when: ios_configuration_rollback_pre_hook is defined and ios_config_rollback_enabled
+
+    - name: rollback configuration
+      cli:
+        command: "config replace flash:/{{ ios_config_temp_config_file }} force"
+      when: ios_config_rollback_enabled
+
+    - name: remove configuration checkpoint file
+      cli:
+        command: "delete /force flash:/{{ ios_config_checkpoint_filename }}"
+      when: ios_config_remove_temp_files
+
+    - name: configuration rollback post hook
+      include_tasks: "{{ ios_configuration_rollback_post_hook }}"
+      when: ios_configuration_rollback_post_hook is defined and ios_config_rollback_enabled
+
+    - name: remove remote temp files
+      cli:
+        command: "delete /force flash:/{{ filename }}"
+      loop:
+        - "{{ ios_config_temp_config_file }}"
+        - "{{ ios_config_checkpoint_filename }}"
+      loop_control:
+        loop_var: filename
+      when: ios_config_remove_temp_files
+
+    - name: remove local temp working dir
+      file:
+        path: "{{ ios_config_working_dir }}"
+        state: absent
+      run_once: true
+      when: ios_config_remove_temp_files
+
+    - name: display message
+      debug:
+        msg: "successfully completed configuration rollback"
+      when: ios_config_rollback_enabled
+
+    - name: fail host due to config load error
+      fail:
+        msg: "error loading configuration onto target device"
+
+  when: not ansible_check_mode
+
+# copy the updated running-config to the local flash device to be used to
+# generate a configuration diff between the before and after
+# running-configurations.
+- name: copy running-config to active config
+  ios_command:
+    commands:
+      - command: "copy running-config flash:{{ ios_config_active_config }}"
+        prompt: ["? "]
+        answer: "{{ ios_config_active_config }}"
+
+# generate the configuration diff and display the diff to stdout.  only set
+# changed if there are lines in the diff that have changed
+- name: generate ios diff
+  cli:
+    command: "show archive config differences flash:{{ ios_config_checkpoint_filename }} flash:{{ ios_config_active_config }}"
+  register: ios_config_diff
+  changed_when: "'No changes were found' not in ios_config_diff.stdout"
+
+- name: display config diff
+  debug:
+    msg: "{{ ios_config_diff.stdout.splitlines() }}"
+  when: not ansible_check_mode
+
+# refresh the list of files currently on the target network device flash
+# drive and remote all temp files
+- name: update local directory listing
+  cli:
+    command: dir
+  register: ios_dir_listing
+
+- name: remove remote temp files from flash
+  cli:
+    command: "delete /force flash:/{{ filename }}"
+  loop:
+    - "{{ ios_config_active_config }}"
+    - "{{ ios_config_checkpoint_filename }}"
+    - "{{ ios_config_temp_config_file }}"
+  loop_control:
+    loop_var: filename
+  when: ios_config_remove_temp_files and filename in ios_dir_listing.stdout
+
+- name: remove local temp working dir
+  file:
+    path: "{{ ios_config_working_dir }}"
+    state: absent
+  run_once: true
+  when: ios_config_remove_temp_files
+  changed_when: False

--- a/tasks/load_config.yaml
+++ b/tasks/load_config.yaml
@@ -1,8 +1,0 @@
----
-- name: load config file contents
-  set_fact:
-    ios_config_text: "{{ lookup('config_template', ios_config_file) | join('\n') }}"
-  when: ios_config_file != ''
-
-- name: invoke configure
-  include_tasks: configure.yaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,25 +1,15 @@
 ---
 # tasks file for ansible-network.cisco_ios
 #
-- name: set the role version
-  set_fact:
-    ansible_network_ios_version: "devel"
-
-- name: display the role version to stdout
-  debug:
-    msg: "ansible_network.ios version {{ ansible_network_ios_version }}"
-
-- name: validate ansible_network_os == 'ios'
-  fail:
-    msg: this role only works with cisco ios devices
-  when: ansible_network_os != 'ios'
+- name: initialize function
+  include_tasks: includes/init.yaml
 
 - name: set role supported functions
   set_fact:
     ios_functions:
       - get_facts
-      - get_config
-      - load_config
+      - config_manager/get
+      - config_manager/load
       - noop
 
 - name: validate the requested function is supported


### PR DESCRIPTION
This change refactors the config tasks to be part of the config_manager
role.  All configuration tasks have now been moved into the
tasks/config_manager folder and renamed to coincide with the
config_manager role.