### PR TITLE
update main.yml to include init tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,5 @@ ios_config_source:
 
 ios_get_facts_command_map: "{{ role_path }}/vars/get_facts_command_map.yaml"
 ios_get_facts_subset: "{{ subset | default(['default']) }}"
+
+ios_vrf_definitions_purge: False

--- a/includes/init.yaml
+++ b/includes/init.yaml
@@ -1,0 +1,19 @@
+---
+- name: set role basic facts
+  set_fact:
+    ansible_network_ios_path: "{{ role_path }}"
+    ansible_network_ios_version: "devel"
+
+- name: display the role version to stdout
+  debug:
+    msg: "ansible_network.cisco_ios version is {{ ansible_network_ios_version }}"
+
+- name: validate ansible_network_os == 'ios'
+  fail:
+    msg: "expected ansible_network_os to be `ios`, got `{{ ansible_network_os }}`"
+  when: ansible_network_os != 'ios'
+
+- name: validate ansible_connection == 'network_cli'
+  fail:
+    msg: "expected ansible_network to be `network_cli`, got `{{ ansible_connection }}`"
+  when: ansible_connection != 'network_cli'


### PR DESCRIPTION
This change updates the main.yml implementation to use the init.yaml set
of tasks in the includes folder.  The init.yaml is designed to be used
by an of the tasks in this role to check for basic values to be set in
order for the role to operate seamlessly.