### PR TITLE
update the config_manager functions to include init

### DIFF
--- a/tasks/config_manager/get.yaml
+++ b/tasks/config_manager/get.yaml
@@ -1,8 +1,6 @@
 ---
-- name: validate required connection is configured
-  fail:
-    msg: "expected connection value to be set to network_cli, got {{ ansible_connection }}"
-  when: ansible_connection != 'network_cli'
+- name: initialize function
+  include_tasks: includes/init.yaml
 
 - name: run command and return configuration
   cli:

--- a/tasks/config_manager/load.yaml
+++ b/tasks/config_manager/load.yaml
@@ -1,4 +1,7 @@
 ---
+- name: initialize function
+  include_tasks: includes/init.yaml
+
 - name: load config file contents
   set_fact:
     ios_config_text: "{{ lookup('config_template', ios_config_file) | join('\n') }}"

--- a/tasks/config_manager/save.yaml
+++ b/tasks/config_manager/save.yaml
@@ -1,0 +1,7 @@
+---
+- name: initialize function
+  include_tasks: includes/init.yaml
+
+- name: run command and return configuration
+  cli:
+    command: "copy running-config startup-config"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
       - get_facts
       - config_manager/get
       - config_manager/load
+      - config_manager/save
       - noop
 
 - name: validate the requested function is supported


### PR DESCRIPTION
This change updates the config_manager functions to now use the init
tasks in includes to validate the role is properly configured before
attempting to execute.

This change adds the missing save function to fully support the
config_manager implementation.

This change updates the main.yml file to include the config_manager
functions to be included for direct role access