### PR TITLE
map config_manger args to provider specific args

### DIFF
--- a/includes/args_adapter.yaml
+++ b/includes/args_adapter.yaml
@@ -1,0 +1,14 @@
+---
+# Playbook to ingest config manager args into ios provider specific args
+#
+
+- name: convert config_manager_text
+  set_fact:
+    ios_config_text: "{{ config_manager_text }}"
+  when: config_manager_text is defined
+
+- name: convert config_manager_file
+  set_fact:
+    ios_config_file: "{{ config_manager_file }}"
+  when: config_manager_file is defined
+

--- a/tasks/config_manager/load.yaml
+++ b/tasks/config_manager/load.yaml
@@ -2,6 +2,9 @@
 - name: initialize function
   include_tasks: includes/init.yaml
 
+- name: Convert higher layer args to provider specific args
+  include_tasks: includes/args_adapter.yaml
+
 - name: load config file contents
   set_fact:
     ios_config_text: "{{ lookup('config_template', ios_config_file) | join('\n') }}"


### PR DESCRIPTION
I was trying to play below config when I got error from provider role that ios_config_text is not defined. This PR will convert config_manager args to provider specific args. In future same playbook can be used to convert intent based args to OS specific args.

- hosts: csr01
  roles:
    - ansible-network.config_manager
  vars:
    ansible_network_provider: cisco_ios
    function: load
    config_manager_text: "interface loopback 100"