### PR TITLE
config rollback issues

### DIFF
--- a/tasks/config_manager/load.yaml
+++ b/tasks/config_manager/load.yaml
@@ -155,13 +155,8 @@
 
     - name: rollback configuration
       cli:
-        command: "config replace flash:/{{ ios_config_temp_config_file }} force"
+        command: "config replace flash:/{{ ios_config_checkpoint_filename }} force"
       when: ios_config_rollback_enabled
-
-    - name: remove configuration checkpoint file
-      cli:
-        command: "delete /force flash:/{{ ios_config_checkpoint_filename }}"
-      when: ios_config_remove_temp_files
 
     - name: configuration rollback post hook
       include_tasks: "{{ ios_configuration_rollback_post_hook }}"


### PR DESCRIPTION
My use-case was as below
1.  I had following ospf config on router 
csr01#show running-config | sec ospf
router ospf 10
 network 13.1.1.128 0.0.0.1 area 1
 network 14.1.1.128 0.0.0.1 area 1

2. now I wanted to change it to new networks in same ospf process. So I wrote below playbook
```
---
- hosts: csr01
  roles:
    - ansible-network.config_manager
  vars:
    ansible_network_provider: cisco_ios
    function: load
    config_manager_file: "{{ ansible_host }}_config.j2"
```
and configs in file were as below
```
(cisco)$ cat templates/11.1.1.20_config.j2 
no router ospf 10
!
router ospf 10
 network  14.1.1.0 0.0.0.255 area 1
 neighbor 13.1.1.0 0.0.0.255 area 1
(cisco)#
```
but here by mistake I wrote 'neighbour' instead of 'network'

3. I was expecting after playbook play my router config would come back to step1
but I encountered two issues 

a) first time I got below error -
```
TASK [cisco_ios : remove remote temp files] ***************************************************************************************************
ok: [csr01] => (item=tmp_csr01) => {"changed": false, "filename": "tmp_csr01", "json": null, "stdout": ""}
fatal: [csr01]: FAILED! => {"msg": "delete /force flash:/chk_ansible\r\n%Error deleting bootflash:/chk_ansible (No such file or directory)\r\ncsr01#"}
        to retry, use: --limit @/macos/net_role/dev/playbooks/cisco/ios_load_cfg.retry

```
This is due to multiple delete of same file in playbook.

b. My configs did not restored .This looks like due to mismatch of filename which had checkpoint configuration.

