### PR TITLE
fixing issue testing config fail issue and changelogs for r 2.6.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,33 @@
 cisco_ios
 ===============================
 
+.. _cisco_ios_v2.6.1:
+
+v2.6.1
+======
+
+.. _cisco_ios_v2.6.1_New Action Plugins:
+
+New Action Plugins
+------------------
+
+- NEW ``ios_user_manager`` action plugin
+
+.. _cisco_ios_v2.6.1_New Tasks:
+
+New Tasks
+---------
+
+- NEW ``configure_user`` task
+
+.. _cisco_ios_v2.6.1_Bugfixes:
+
+Bugfixes
+--------
+
+- Refactor vrf and bgp output and improve reliability (#29)
+- better support for working with config_manager tasks
+
 devel
 =====
 

--- a/includes/checkpoint/create.yaml
+++ b/includes/checkpoint/create.yaml
@@ -1,8 +1,8 @@
 ---
-- name: validate ios_checkpoint_filename is defined
+- name: validate ios_config_checkpoint_filename is defined
   fail:
-    msg: "missing required var: ios_checkpoint_filename"
-  when: ios_checkpoint_filename is undefined
+    msg: "missing required var: ios_config_checkpoint_filename"
+  when: ios_config_checkpoint_filename is undefined
 
 - name: get current files on disk
   cli:

--- a/tasks/config_manager/load.yaml
+++ b/tasks/config_manager/load.yaml
@@ -9,7 +9,7 @@
 
 - name: set ios checkpoint filename
   set_fact:
-    ios_checkpoint_filename: "chk_ansible"
+    ios_config_checkpoint_filename: "chk_ansible"
 
 # initiate creating a checkpoint of the existing running-config
 - name: create checkpoint of current configuration
@@ -82,7 +82,7 @@
 # changed if there are lines in the diff that have changed
 - name: generate ios diff
   cli:
-    command: "show archive config differences flash:{{ ios_checkpoint_filename }} flash:{{ ios_active_config }}"
+    command: "show archive config differences flash:{{ ios_config_checkpoint_filename }} flash:{{ ios_active_config }}"
   register: ios_config_diff
   changed_when: "'No changes were found' not in ios_config_diff.stdout"
 
@@ -103,7 +103,7 @@
     command: "delete /force flash:/{{ filename }}"
   loop:
     - "{{ ios_active_config }}"
-    - "{{ ios_checkpoint_filename }}"
+    - "{{ ios_config_checkpoint_filename }}"
   loop_control:
     loop_var: filename
   when: filename in ios_dir_listing.stdout


### PR DESCRIPTION
while testing found fact 'ios_config_checkpoint_filename' is used at more places and it might be better to use this fact for backward compatibility with v2.6.0