### PR TITLE
update the checkpoint filename

### DIFF
--- a/includes/checkpoint/create.yaml
+++ b/includes/checkpoint/create.yaml
@@ -1,8 +1,8 @@
 ---
-- name: validate ios_config_checkpoint_filename is defined
+- name: validate ios_checkpoint_filename is defined
   fail:
-    msg: "missing required var: ios_config_checkpoint_filename"
-  when: ios_config_checkpoint_filename is undefined
+    msg: "missing required var: ios_checkpoint_filename"
+  when: ios_checkpoint_filename is undefined
 
 - name: get current files on disk
   cli:
@@ -11,8 +11,8 @@
 
 - name: remove old checkpoint file (if necessary)
   cli:
-    command: "delete /force flash:/{{ ios_config_checkpoint_filename }}"
-  when: ios_config_checkpoint_filename in ios_dir_listing.stdout
+    command: "delete /force flash:/{{ ios_checkpoint_filename }}"
+  when: ios_checkpoint_filename in ios_dir_listing.stdout
 
 # copy the current running-config to the local flash disk on the target device.
 # This will be used both for restoring the current config if a failure happens
@@ -21,6 +21,6 @@
 - name: create a checkpoint of the current running-config
   ios_command:
     commands:
-      - command: "copy running-config flash:{{ ios_config_checkpoint_filename }}"
+      - command: "copy running-config flash:{{ ios_checkpoint_filename }}"
         prompt: ["\\? "]
-        answer: "{{ ios_config_checkpoint_filename }}"
+        answer: "{{ ios_checkpoint_filename }}"

--- a/includes/checkpoint/remove.yaml
+++ b/includes/checkpoint/remove.yaml
@@ -1,8 +1,8 @@
 ---
-- name: validate ios_config_checkpoint_filename is defined
+- name: validate ios_checkpoint_filename is defined
   fail:
-    msg: "missing required var: ios_config_checkpoint_filename"
-  when: ios_config_checkpoint_filename is undefined
+    msg: "missing required var: ios_checkpoint_filename"
+  when: ios_checkpoint_filename is undefined
 
 - name: get current files on disk
   cli:
@@ -11,5 +11,5 @@
 
 - name: remove checkpoint file from remote device
   cli:
-    command: "delete /force flash:/{{ ios_config_checkpoint_filename }}"
-  when: ios_config_checkpoint_filename in ios_dir_listing.stdout
+    command: "delete /force flash:/{{ ios_checkpoint_filename }}"
+  when: ios_checkpoint_filename in ios_dir_listing.stdout

--- a/includes/checkpoint/restore.yaml
+++ b/includes/checkpoint/restore.yaml
@@ -1,8 +1,8 @@
 ---
-- name: validate ios_config_checkpoint_filename is defined
+- name: validate ios_checkpoint_filename is defined
   fail:
-    msg: "missing required var: ios_config_checkpoint_filename"
-  when: ios_config_checkpoint_filename is undefined
+    msg: "missing required var: ios_checkpoint_filename"
+  when: ios_checkpoint_filename is undefined
 
 - name: get current files on disk
   cli:
@@ -11,8 +11,8 @@
 
 - name: verify checkpoint file exists
   fail:
-    msg: "missing checkpoint file {{ ios_config_checkpoing_filename }}"
-  when: ios_config_checkpoint_filename not in ios_dir_listing.stdout
+    msg: "missing checkpoint file {{ ios_checkpoing_filename }}"
+  when: ios_checkpoint_filename not in ios_dir_listing.stdout
 
 - name: checkpoint configuration restore pre hook
   include_tasks: "{{ ios_checkpoint_restore_pre_hook }}"
@@ -20,7 +20,7 @@
 
 - name: restore checkpoint configuration
   cli:
-    command: "config replace flash:/{{ ios_config_checkpoint_filename }} force"
+    command: "config replace flash:/{{ ios_checkpoint_filename }} force"
 
 - name: checkpoint configuration restore post hook
   include_tasks: "{{ ios_checkpoint_restore_post_hook }}"
@@ -28,4 +28,4 @@
 
 - name: remove checkpoint file from remote device
   cli:
-    command: "delete /force flash:/{{ ios_config_checkpoint_filename }}"
+    command: "delete /force flash:/{{ ios_checkpoint_filename }}"

--- a/tasks/config_manager/load.yaml
+++ b/tasks/config_manager/load.yaml
@@ -9,7 +9,7 @@
 
 - name: set ios checkpoint filename
   set_fact:
-    ios_config_checkpoint_filename: "chk_ansible"
+    ios_checkpoint_filename: "chk_ansible"
 
 # initiate creating a checkpoint of the existing running-config
 - name: create checkpoint of current configuration
@@ -82,7 +82,7 @@
 # changed if there are lines in the diff that have changed
 - name: generate ios diff
   cli:
-    command: "show archive config differences flash:{{ ios_config_checkpoint_filename }} flash:{{ ios_active_config }}"
+    command: "show archive config differences flash:{{ ios_checkpoint_filename }} flash:{{ ios_active_config }}"
   register: ios_config_diff
   changed_when: "'No changes were found' not in ios_config_diff.stdout"
 
@@ -103,7 +103,7 @@
     command: "delete /force flash:/{{ filename }}"
   loop:
     - "{{ ios_active_config }}"
-    - "{{ ios_config_checkpoint_filename }}"
+    - "{{ ios_checkpoint_filename }}"
   loop_control:
     loop_var: filename
   when: filename in ios_dir_listing.stdout


### PR DESCRIPTION
This change updates how the checkpoint filename is derived.  It changes
the checkpoint filename to ios_checkpoint_filename and updates the
config_manager/load function to use the new filename fact value.