### PR TITLE
test improvements

### DIFF
--- a/includes/checkpoint/restore.yaml
+++ b/includes/checkpoint/restore.yaml
@@ -21,6 +21,7 @@
 - name: restore checkpoint configuration
   cli:
     command: "config replace flash:/{{ ios_checkpoint_filename }} force"
+  register: ios_rollback_results
 
 - name: checkpoint configuration restore post hook
   include_tasks: "{{ ios_checkpoint_restore_post_hook }}"

--- a/tests/config_manager/config_manager/tasks/load.yml
+++ b/tests/config_manager/config_manager/tasks/load.yml
@@ -22,12 +22,14 @@
     ansible_network_provider: "{{ cisco_ios_role }}"
     function: load
     config_manager_text: "{{ config_text_valid }}"
-  register: result
 
-# FIXME: above task does not return changed == true even if there is diff
 - assert:
     that:
-      -  result.changed == true
+      - "'No changes were found' not in ios_config_diff.stdout"
+
+- name: set config_manager_text with all valid config to induce change in running-config
+  set_fact:
+    config_valid: "{{lookup('file', config_files_path + '/csr01_config_valid.j2')}}"
 
 - name: load valid configurations into device using config file
   include_role:
@@ -35,24 +37,26 @@
   vars:
     ansible_network_provider: "{{ cisco_ios_role }}"
     function: load
-    config_manager_file: "{{ config_files_path }}/csr01_config_valid.j2"
-  register: result
-
-# FIXME: above task does not return changed == true even if there is diff
-- assert:
-    that:
-      -  result.changed == true
-
-- name: test rollback in case of wrong config using file
-  include_role:
-    name:  "{{ config_manager_role }}"
-  vars:
-    ansible_network_provider: "{{ cisco_ios_role }}"
-    function: load
-    config_manager_file: "{{ config_files_path }}/csr01_config_error.j2"
-  register: result
-  ignore_errors: true
+    config_manager_text: "{{ config_valid }}"
 
 - assert:
     that:
-      -  result.failed == true
+      - "'No changes were found' not in ios_config_diff.stdout"
+
+- name: set config_manager_text from lookup of a file with few invalid configs to test rollback
+  set_fact:
+    config_with_errors: "{{lookup('file', config_files_path + '/csr01_config_error.j2')}}"
+
+- block: 
+    - name: test rollback in case of wrong config using file
+      include_role:
+        name:  "{{ config_manager_role }}"
+      vars:
+        ansible_network_provider: "{{ cisco_ios_role }}"
+        function: load
+        config_manager_text: "{{ config_with_errors }}"
+      register: result
+  rescue:
+    - assert:
+        that:
+          - "'Rollback Done' in ios_rollback_results.stdout"


### PR DESCRIPTION
- generate ios_config_text from lookup plugin
- register a var in rollback tasks to check stdout from iOS device to verify rollback in more reliable way
- change in assert conditions to directly test global var ios_config_diff  for expected diffs

All tests are passing with this change
```
ansible-playbook -i /tmp/in test_config_manager.yaml
<snip>
TASK [assert] ******************************************************************************************************************************************
task path: /macos/net_role/dev/roles/gdpak_cisco_ios/tests/config_manager/config_manager/tasks/load.yml:60
ok: [csr01] => {
    "changed": false, 
    "msg": "All assertions passed"
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************************************************************************************
csr01                      : ok=118  changed=3    unreachable=0    failed=3   
```