### PR TITLE
Switch tox -elinters to python3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ skipsdist = True
 envlist = linters
 
 [testenv]
-basepython = python3
 install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
+basepython = python3
 commands =
   flake8 {posargs}
 


### PR DESCRIPTION
This is more inline with other roles for testing. Also allows us to run
jobs on centos-7, which doesn't have python3.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>