### PR TITLE
Rename ip_version field to be more correct

### DIFF
--- a/parser_templates/cli/show_ip_bgp_summary.yaml
+++ b/parser_templates/cli/show_ip_bgp_summary.yaml
@@ -75,3 +75,5 @@
             value: "{{ item.timer }}"
           - key: ip_version
             value: "{{ item.version }}"
+          - key: bgp_version
+            value: "{{ item.version }}"

--- a/tests/output/cli/show_ip_bgp_summary/main.yaml
+++ b/tests/output/cli/show_ip_bgp_summary/main.yaml
@@ -30,7 +30,7 @@
       - "'10.29.19.70' in bgp['neighbors']"
       - bgp['neighbors']['10.29.19.70']['state_pfxrcd'] == 1385
       - bgp['neighbors']['10.29.19.70']['asn'] == 7474
-      - bgp['neighbors']['10.29.19.70']['ip_version'] == 4
+      - bgp['neighbors']['10.29.19.70']['bgp_version'] == 4
       - bgp['neighbors']['10.29.19.70']['timer'] == '4d22h'
 
 - name: clear facts
@@ -51,11 +51,11 @@
       - "'172.16.32.1' in bgp['neighbors']"
       - bgp['neighbors']['172.31.32.10']['state_pfxrcd'] == 114
       - bgp['neighbors']['172.31.32.10']['asn'] == 64910
-      - bgp['neighbors']['172.31.32.10']['ip_version'] == 4
+      - bgp['neighbors']['172.31.32.10']['bgp_version'] == 4
       - bgp['neighbors']['172.31.32.10']['timer'] == '23w5d'
       - bgp['neighbors']['172.16.32.1']['state_pfxrcd'] == 136
       - bgp['neighbors']['172.16.32.1']['asn'] == 65123
-      - bgp['neighbors']['172.16.32.1']['ip_version'] == 4
+      - bgp['neighbors']['172.16.32.1']['bgp_version'] == 4
       - "'{{ bgp['neighbors']['172.16.32.1']['timer'] | string }}' == '28w5d'"
 
 - name: clear facts
@@ -77,15 +77,15 @@
       - "'72.31.0.13' in bgp['neighbors']"
       - bgp['neighbors']['10.15.17.2']['state_pfxrcd'] == 1125
       - bgp['neighbors']['10.15.17.2']['asn'] == 64785
-      - bgp['neighbors']['10.15.17.2']['ip_version'] == 4
+      - bgp['neighbors']['10.15.17.2']['bgp_version'] == 4
       - bgp['neighbors']['10.15.17.2']['timer'] == '7w1d'
       - bgp['neighbors']['10.1.19.2']['state_pfxrcd'] == 'Active'
       - bgp['neighbors']['10.1.19.2']['asn'] == 1234
-      - bgp['neighbors']['10.1.19.2']['ip_version'] == 4
+      - bgp['neighbors']['10.1.19.2']['bgp_version'] == 4
       - "'{{ bgp['neighbors']['10.1.19.2']['timer'] | string }}' == '00:00:30'"
       - bgp['neighbors']['72.31.0.13']['state_pfxrcd'] == 'Idle'
       - bgp['neighbors']['72.31.0.13']['asn'] == 65004
-      - bgp['neighbors']['72.31.0.13']['ip_version'] == 4
+      - bgp['neighbors']['72.31.0.13']['bgp_version'] == 4
       - "'{{ bgp['neighbors']['72.31.0.13']['timer'] | string }}' == '10:32:44'"
 
 ### Done


### PR DESCRIPTION
The version in the output of show ip bgp summary is not signifying the IP version, but rather the BGP version. Change the name of the field in order to reflect this.

This does break backwards compatibility though, so please let me know how to proceed in such a case.