### PR TITLE
cisco_ios: Replace config_manager_file with config_manager_text

### DIFF
--- a/tasks/configure_user.yaml
+++ b/tasks/configure_user.yaml
@@ -40,7 +40,7 @@
 
 - name: "fetch template for configuring user(s)"
   set_fact:
-    config_manager_file: 'configure_user.j2'
+    config_manager_text: "{{ lookup('config_template', 'configure_user.j2') }}"
   when: users
   delegate_to: localhost
 


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

- Replaced `config_manager_file` with `config_manager_text` for `configure_user` task.