### PR TITLE
Cli textfsm fixes

### DIFF
--- a/includes/configure/terminal.yaml
+++ b/includes/configure/terminal.yaml
@@ -15,7 +15,7 @@
           loop: "{{ ios_config_text | to_lines }}"
           loop_control:
             loop_var: line
-          when: line != 'end' and and line != ''
+          when: line != 'end' and line != ''
           register: ios_config_output
 
         - name: fail any lines that generated an error

--- a/includes/configure/terminal.yaml
+++ b/includes/configure/terminal.yaml
@@ -15,7 +15,7 @@
           loop: "{{ ios_config_text | to_lines }}"
           loop_control:
             loop_var: line
-          when: line != 'end'
+          when: line != 'end' and and line != ''
           register: ios_config_output
 
         - name: fail any lines that generated an error

--- a/includes/run_cli.yaml
+++ b/includes/run_cli.yaml
@@ -8,6 +8,7 @@
     command: "{{ ios_command }}"
     parser: "{{ parser }}"
     engine: "{{ ios_parser_engine | default(None) }}"
+    key_name: "{{ ios_facts_key | default(None) }} "
   with_first_found:
     - files:
         - "{{ ios_parser }}"

--- a/includes/run_cli.yaml
+++ b/includes/run_cli.yaml
@@ -8,7 +8,7 @@
     command: "{{ ios_command }}"
     parser: "{{ parser }}"
     engine: "{{ ios_parser_engine | default(None) }}"
-    key_name: "{{ ios_facts_key | default(None) }} "
+    name: "{{ ios_name | default(None) }} "
   with_first_found:
     - files:
         - "{{ ios_parser }}"

--- a/tasks/get_facts.yaml
+++ b/tasks/get_facts.yaml
@@ -13,6 +13,7 @@
     ios_command: "{{ item.command }}"
     ios_parser: "cli/{{ item.parser }}"
     ios_parser_engine: "{{ item.engine | default('command_parser') }}"
+    ios_facts_key: "{{ item.name | default(None) }}"
     ios_run_cli_command_pre_hook: "{{ item.pre_hook | default(None) }}"
     ios_run_cli_command_post_hook: "{{ item.post_hook | default(None) }}"
   loop: "{{ lookup('file', ios_get_facts_command_map) | from_yaml }}"

--- a/tasks/get_facts.yaml
+++ b/tasks/get_facts.yaml
@@ -13,7 +13,7 @@
     ios_command: "{{ item.command }}"
     ios_parser: "cli/{{ item.parser }}"
     ios_parser_engine: "{{ item.engine | default('command_parser') }}"
-    ios_facts_key: "{{ item.name | default(None) }}"
+    ios_name: "{{ item.name | default(None) }}"
     ios_run_cli_command_pre_hook: "{{ item.pre_hook | default(None) }}"
     ios_run_cli_command_post_hook: "{{ item.post_hook | default(None) }}"
   loop: "{{ lookup('file', ios_get_facts_command_map) | from_yaml }}"

--- a/vars/get_facts_command_map.yaml
+++ b/vars/get_facts_command_map.yaml
@@ -9,6 +9,7 @@
 #   * command - the cli command to execute on the target device
 #   * parser - the filename of the parser relative to parse_templates/cli
 #   * engine - one of `command_parser` (default) or `textfsm_parser`
+#   * name - name of dictionary key to store new ansible_facts, only relevant for `textfsm_parser` engine
 #   * groups - a list of one or more groups the commadn belongs to
 #   * pre_hook - path to the set of tasks to execute before running the command
 #   * post_hook - path to the set of tasks to execute after running the command


### PR DESCRIPTION
Currently there's no way to get textfsm_parser to populate ansible_facts with this role. We need to pass name to the parser to set the dictionary key facts will be added to. I have a separate pull request for ansible-network.network-engine to take in this argument to the cli module.
I also fixed issue where cli would fail when terminal.yaml would pass a blank line showing up from jinja render, now terminal.yaml just skips those blank lines.

Signed-off-by: jwoogee <jswoods1@gmail.com>