### PR TITLE
Add bindep.txt file

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,7 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see http://docs.openstack.org/infra/bindep/ for additional information.
+
+gcc-c++ [test platform:rpm]
+python3-devel [test platform:rpm]
+python3 [test platform:rpm]
+python36 [test !platform:fedora-28]


### PR DESCRIPTION
We use bindep.txt to manage the OS level dependencies jobs need.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>