### PR TITLE
Fixed show_interfaces parsing

### DIFF
--- a/parser_templates/cli/show_interfaces.yaml
+++ b/parser_templates/cli/show_interfaces.yaml
@@ -7,7 +7,7 @@
 
 - name: match sections
   pattern_match:
-    regex: "^\\S+ is up,"
+    regex: "^\\S+ is (up|down|administratively down),"
     match_all: yes
     match_greedy: yes
   register: context


### PR DESCRIPTION
Incongruent parsing due to requiring the interface to be up. Changed to allow the line to be
    Interface is (up|down|administratively down),