### PR TITLE
show interfaces parsing was incorrect due to only allowing for up interfaces

### DIFF
--- a/parser_templates/cli/show_interfaces.yaml
+++ b/parser_templates/cli/show_interfaces.yaml
@@ -7,7 +7,7 @@
 
 - name: match sections
   pattern_match:
-    regex: "^\\S+ is up,"
+    regex: "^\\S+ is (up|down|administratively down),"
     match_all: yes
     match_greedy: yes
   register: context


### PR DESCRIPTION
Changed to allow (up|down|administratively down)

Signed-off-by: Michael Wiggins <wiggimt@gmail.com>