### PR TITLE
Adding Configure VLAN role support for Cisco-IOS devices

### DIFF
--- a/docs/configure_vlans.md
+++ b/docs/configure_vlans.md
@@ -1,0 +1,101 @@
+# Configure VLANs on the device
+
+The `configure_vlans` function can be used to set VLANs on Cisco IOS devices.
+This function is only supported over `network_cli` connection type and 
+requires the `ansible_network_os` value set to `ios`.
+
+## How to set VLANs on the device
+
+To set VLANs on the device, simply include this function in the playbook
+using either the `roles` directive or the `tasks` directive.  If no other
+options are provided, then all of the available facts will be collected for 
+the device.
+
+Below is an example of how to use the `roles` directive to set VLANs on the 
+Cisco IOS device.
+
+```
+- hosts: ios
+
+  roles:
+  - name ansible-network.cisco_ios
+    function: configure_vlans
+  vars:
+    vlans:
+      - id: 10
+        name: vlan-10
+        status: active
+```
+
+The above playbook will set the VLANs with ID, description, and address to particular
+interface under the `ios` top level key.  
+
+### Implement using tasks
+
+The `configure_vlans` function can also be implemented using the `tasks` directive
+instead of the `roles` directive.  By using the `tasks` directive, you can
+control when the fact collection is run. 
+
+Below is an example of how to use the `configure_vlans` function with `tasks`.
+
+```
+- hosts: ios
+
+  tasks:
+    - name: set vlans to ios devices
+      import_role:
+        name: ansible-network.cisco_ios
+        tasks_from: configure_vlans
+      vars:
+        vlans:
+          - id: 10
+            name: vlan-10
+            status: active 
+```
+
+## Adding new parsers
+
+Over time new parsers can be added (or updated) to the role to add additional
+or enhanced functionality.  To add or update parsers perform the following
+steps:
+
+* Add (or update) command parser located in `parse_templates/cli`
+
+## Arguments
+
+### id
+
+VLAN will be configured on the Cisco IOS device using respective ID over the interface
+and this is also a mandatory parameter.
+
+This being a mandatory parameter which means even if the user doesn't pass the respective
+argument the role will fail to run with missing argument error. Also, valid VLANs id
+range is 1-4094, so the role checks if the user value for the argument matches the range
+and if not the execution of the role fails with id range error
+
+### name
+
+This sets the name for the VLAN Id for the Cisco IOS device.
+
+The default value is `omit` which means even if the user doesn't pass the respective 
+value the role will continue to run without any failure.
+
+### status
+
+This sets the status for the VLAN Id for the Cisco IOS device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### state
+
+This sets the VLANs value to the Cisco IOS device and if the value of the state is changed
+to `absent`, the role will go ahead and try to delete the VLANs via the arguments passed.
+
+The default value is `present` which means even if the user doesn't pass the respective
+argument, the role will go ahead and try to set the VLANs via the arguments passed to the 
+Cisco IOS device.
+
+## Notes
+
+None

--- a/tasks/configure_vlans.yaml
+++ b/tasks/configure_vlans.yaml
@@ -1,0 +1,47 @@
+---
+- name: "check for required fact - interface"
+  fail:
+    msg: "missing required fact: Interface"
+  with_items: "{{ vlans }}"
+  when: ( vlan.interface is not defined )
+  loop_control:
+    loop_var: vlan
+  delegate_to: localhost
+
+- name: "check for required fact - vlan ID"
+  fail:
+    msg: "missing required fact: Vlan ID"
+  with_items: "{{ vlans }}"
+  when: ( vlan.id is not defined )
+  loop_control:
+    loop_var: vlan
+  delegate_to: localhost
+
+- name: "check if vlan ID is greater than 1"
+  fail:
+    msg: "vlan_id is less than 1 (valid-range: 1-4094)"
+  with_items: "{{ vlans }}"
+  loop_control:
+    loop_var: vlan
+  when:
+    - vlan.id < 1
+  delegate_to: localhost
+
+- name: "check if vlan ID is less than 4094"
+  fail:
+    msg: "vlan_id is greater than 4094 (valid-range: 1-4094)"
+  with_items: "{{ vlans }}"
+  loop_control:
+    loop_var: vlan
+  when:
+    - vlan.id > 4094
+  delegate_to: localhost
+
+- name: "fetch template for configuring vlan(s)"
+  set_fact:
+    config_manager_text: "{{ lookup('config_template', 'configure_vlans.j2') }}"
+  when: vlans
+  delegate_to: localhost
+
+- include_tasks: config_manager/load.yaml
+  when: vlans

--- a/templates/configure_vlans.j2
+++ b/templates/configure_vlans.j2
@@ -1,0 +1,16 @@
+{% for vlan in vlans %}
+
+{% if vlan.state is defined and vlan.state == 'absent' %}
+interface {{ vlan.interface }}
+no vlan-id dot1q {{ vlan.id }}
+
+{% else %}
+
+interface {{ vlan.interface }}
+vlan-id dot1q {{ vlan.id }}
+bridge-group {{ vlan.bridge_group | default(omit) }}
+description {{ vlan.description | default(omit) }}
+pppoe {{ vlan.ppoe | default(omit) }}
+
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
Added configure_vlan and configure_vlan jinja template for Cisco IOS device provider to configure vlan using ios device provider role.

To configure vlan via this role user needs to build their playbook as:
```
---
- hosts: ios
  gather_facts: no
  tasks:
    - import_role:
        name: cisco_ios
        tasks_from: configure_vlans
      vars:
        vlans:
          - interface: GigabitEthernet 0/2
            id: 30
            bridge_group: 10
            description: this is Vlan with ID 30
            ppoe: enable
            #state: absent
```