### PR TITLE
Gate on flak8 W rules

### DIFF
--- a/action_plugins/extract_banners.py
+++ b/action_plugins/extract_banners.py
@@ -30,7 +30,7 @@ options:
 """
 
 EXAMPLES = """
-- name: extract multiline banners 
+- name: extract multiline banners
   extract_banners:
     config: "{{ ios_config_text }}"
 
@@ -102,7 +102,7 @@ class ActionModule(ActionBase):
                     banner_start_index = linenum
                     found_banner_start = 1
                     continue
-    
+
             if found_banner_start:
                 # Search for delimiter found in current banner start
                 regex = r'%s' % banner_delimiter_esc
@@ -116,7 +116,7 @@ class ActionModule(ActionBase):
                         'banner_end_index': linenum,
                     }
                     banner_meta.append(kwargs)
-    
+
         # Build banners from extracted data
         banner_lines = []
         for banner in banner_meta:
@@ -126,13 +126,13 @@ class ActionModule(ActionBase):
             for index, conf_line in enumerate(banner_conf_lines):
                 banner_lines.append(conf_line)
             banner_lines.append('%s' % banner['banner_delimiter'])
-    
+
         # Delete banner lines from config
         for banner in banner_meta:
             banner_lines_range = range(banner['banner_start_index'],
                                        banner['banner_end_index'] + 1)
             for index in banner_lines_range:
                 config_lines[index] = '! banner removed'
-   
+
         configs = '\n'.join(config_lines)
         return (banner_lines, configs)

--- a/action_plugins/verify_dependent_role_version.py
+++ b/action_plugins/verify_dependent_role_version.py
@@ -137,7 +137,6 @@ class ActionModule(ActionBase):
                 return ("Error", msg)
 
         return ("Success", 'Success: All dependent roles meet min version requirements')
-                  
 
     def _check_depends(self, depends, depends_dict):
         depends_list = []

--- a/library/ios_user_manager.py
+++ b/library/ios_user_manager.py
@@ -20,7 +20,7 @@ short_description: Manage an aggregate of users in IOS device(s)
 description:
     - Allows the `cisco_ios` provider role to manage aggregate of users
       by providing idempotency and other utility functions while running
-      the `configure_user` task 
+      the `configure_user` task
 version_added: "2.7"
 options:
   new_users:
@@ -29,7 +29,7 @@ options:
     required: true
   user_config:
     description:
-      - User config lines extracted from the devices' running-configuration 
+      - User config lines extracted from the devices' running-configuration
     required: true
 author:
   - Nilashish Chakraborty (@NilashishC)
@@ -39,7 +39,7 @@ stdout:
   description: Filtered set of users that should be configured on the device
   returned: always apart from low-level errors (such as action plugin)
   type: list
-  sample: [{"name": "ansible", "privilege": 15}, {"name": "test_user", "privilege": 15, "view": "sh_int"}]  
+  sample: [{"name": "ansible", "privilege": 15}, {"name": "test_user", "privilege": 15, "view": "sh_int"}]
 """
 EXAMPLES = '''
 - ios_user_manager:

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands = {posargs}
 [flake8]
 # TODO(pabelanger): Follow sane flake8 rules for galaxy and sync across all of
 # ansible-network.
-ignore = E111,E114,E125,E128,E129,E201,E202,E203,E272,E302,E303,E402,F401,F841,W291,W292,W293
+ignore = E111,E114,E125,E128,E129,E201,E202,E203,E272,E302,E303,E402,F401,F841
 max-line-length = 160
 show-source = True
-exclude = .venv,.tox,dist,doc,build,*.egg
+exclude = .tox,dist,build,*.egg


### PR DESCRIPTION
This cleans up flake8 errors for the W rules and starts gating PRs on
it. This helps to ensure new patches are written in a common format.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>