### PR TITLE
Add tox test to validate parser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ansible

--- a/tests/parser_templates/cli/show_interfaces/main.yaml
+++ b/tests/parser_templates/cli/show_interfaces/main.yaml
@@ -18,9 +18,9 @@
       - interfaces['GigabitEthernet0/0/1']['admin-status'] == 'enabled'
       - interfaces['Tunnel0']['admin-status'] == 'enabled'
       - interfaces['Tunnel0']['oper-status'] == 'down'
-      - interfaces['GigabitEthernet0']['counters']['in-broadcast-pkts'] == 4891144
+      - interfaces['GigabitEthernet0']['counters']['in-broadcast-pkts'] == '4891144'
       - interfaces['GigabitEthernet0']['counters']['in-multicast-pkts'] == None
-      - interfaces['Virtual-Access1']['mtu'] == 1500
+      - interfaces['Virtual-Access1']['mtu'] == '1500'
       - interfaces['Tunnel2']['description'] == 'tunnel for gloabl routing for SJC'
       - interfaces['GigabitEthernet0/0/5']['type'] == '6XGE-BUILT-IN'
       - interfaces['Tunnel0']['type'] == 'Tunnel'

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -1,0 +1,2 @@
+---
+- import_playbook: test_parser_templates.yaml

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE(pabelanger): Create a symlink for ansible-network.network-engine to keep
+# meta/main.yml happy
+ln -s ~/src/github.com/ansible-network/network-engine \
+  ~/src/github.com/ansible-network/ansible-network.network-engine

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,13 @@ envlist = linters
 
 [testenv]
 install_command = pip install {opts} {packages}
-deps = -r{toxinidir}/test-requirements.txt
+commands =
+  ansible-playbook -v -i tests/inventory tests/test.yaml
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
+setenv =
+  ANSIBLE_CALLBACK_PLUGINS = {envsitepackagesdir}/ara/plugins/callbacks
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
We have an existing test_parser_templates.yaml playbook, lets run it on
every commit to increase our coverage.

Closes: #98
Signed-off-by: Paul Belanger <pabelanger@redhat.com>