### PR TITLE
Missing brackets for multicast packets in

### DIFF
--- a/parser_templates/cli/show_interfaces.yaml
+++ b/parser_templates/cli/show_interfaces.yaml
@@ -58,7 +58,7 @@
 
     - name: match input broadcast
       pattern_match:
-        regex: "Received (\\d+) broadcasts \\(\\d+"
+        regex: "Received (\\d+) broadcasts \\((\\d+)"
         content: "{{ item }}"
       register: in_bcast_mcast
 


### PR DESCRIPTION
Was \\(\\d+
The first \\( is needed but you then need (\\d+) to get the actual value.