### PR TITLE
change to variable to use '_' underscore rather than '-' dash

### DIFF
--- a/parser_templates/config/show_run_interface.yaml
+++ b/parser_templates/config/show_run_interface.yaml
@@ -62,7 +62,7 @@
 
 - name: template interface values
   loop: "{{ values }}"
-  register: interface-config
+  register: interface_config
   export: true
   export_as: dict
   extend: cisco_ios.config


### PR DESCRIPTION
Referencing the variable 'cisco_ios.config.interface-config' results in "VARIABLE IS NOT DEFINED!: 'config' is undefined"

Tasks:
```yaml
    - name: PARSE THE RAW OUTPUT
      command_parser:
        file: "{{ parser_template_dir }}/ios/show_run_interface.yaml"
        content: "{{ ansible_net_config }}"

    - debug: var=cisco_ios.config.interface-config.Vlan1
```

Sample data with -v:
```
TASK [PARSE THE RAW OUTPUT] *******************************************************************************
ok: [cia-lab-3850] => {
    "ansible_facts": {
        "cisco_ios": {
            "config": {
                "interface-config": {
                    "FortyGigabitEthernet1/1/1": {
                        "cdp": true, 
                        "description": null, 
                        "duplex": null, 
                        "enabled": true, 
                        "ip_addess": [], 
                        "ip_helper": [], 
                        "mtu": null, 
                        "name": "FortyGigabitEthernet1/1/1", 
                        "speed": null
                    }, 
                    "FortyGigabitEthernet1/1/2": {
                        "cdp": true, 
                        "description": null, 
                        "duplex": null, 

<truncated>
                    "Vlan1": {
                        "cdp": true, 
                        "description": null, 
                        "duplex": null, 
                        "enabled": true, 
                        "ip_addess": [], 
                        "ip_helper": [], 
                        "mtu": null, 
                        "name": "Vlan1", 
                        "speed": null
                    }
                }
            }
        }
    }, 
    "changed": false, 
    "included": [
        "/var/lib/awx/projects/net_compliance/parser_templates/ios/show_run_interface.yaml"
    ]
}

TASK [debug] **********************************************************************************************
ok: [cia-lab-3850] => {
    "cisco_ios.config.interface-config.Vlan1": "VARIABLE IS NOT DEFINED!: 'config' is undefined"
}
```

After changing variable to use to '_' underscore, the expected data is returned:
```
TASK [debug] **********************************************************************************************
ok: [cia-lab-3850] => {
    "cisco_ios.config.interface_config.Vlan1": {
        "cdp": true, 
        "description": null, 
        "duplex": null, 
        "enabled": true, 
        "ip_addess": [], 
        "ip_helper": [], 
        "mtu": null, 
        "name": "Vlan1", 
        "speed": null
    }
}
```