### PR TITLE
Fix typo in json_template

### DIFF
--- a/parser_templates/config/show_run_interface.yaml
+++ b/parser_templates/config/show_run_interface.yaml
@@ -72,7 +72,7 @@
         object:
           - key: name
             value: "{{ item.name.matches.0 }}"
-          - key: ip_addess
+          - key: ip_address
             value: "{{ item.ip_address | map(attribute='matches') | list }}"
           - key: description
             value: "{{ item.description.matches.0 }}"


### PR DESCRIPTION
There is a typo in the json_template dictionary, key is "ip_addess" but should be "ip_address".